### PR TITLE
Update for aiida-phonopy plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -127,9 +127,9 @@
         "name": "aiida-phonopy",
         "entry_point": "phonopy",
         "state": "development",
-        "plugin_info": "https://raw.githubusercontent.com/abelcarreras/aiida-phonopy/master/setup.json",
-        "code_home": "https://github.com/abelcarreras/aiida-phonopy",
-        "pip_url": "git+https://github.com/abelcarreras/aiida-phonopy",
+        "plugin_info": "https://raw.githubusercontent.com/aiida-phonopy/aiida-phonopy/master/setup.json",
+        "code_home": "https://github.com/aiida-phonopy/aiida-phonopy",
+        "pip_url": "git+https://github.com/aiida-phonopy/aiida-phonopy",
         "documentation_url": "https://aiida-phonopy.readthedocs.io/"
     },
     "lammps": {


### PR DESCRIPTION
This PR is update for aiida-phonopy plugin.
Previously aiida-phonopy was maintained by @abelcarreras but now @atztogo mainly does the job. The aiida-phonopy github repository was moved from that under @abelcarreras to aiida-phonopy organization.